### PR TITLE
Add v4.5.1 + workflows

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -1,0 +1,16 @@
+settings:
+  jira_project_key: "OBC"
+  status_mapping:
+    opened: Untriaged
+    closed: done
+    not_planned: rejected
+
+  components:
+    - cos-configuration
+
+  add_gh_comment: false
+  sync_description: false
+  sync_comments: false
+
+  label_mapping:
+    "Type: Enhancement": Story

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,53 @@
+name: Bug Report
+description: File a bug report
+labels: ["Type: Bug", "Status: Triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to fill out this bug report! Before submitting your issue, please make
+        sure you are using the latest version of the rock. If not, please try upgrading to the latest release prior to
+        posting your report to make sure it's not already solved.
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug Description
+      description: >
+        If applicable, add screenshots to
+        help explain the problem you are facing.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: To Reproduce
+      description: >
+        Please provide step-by-step instructions for how to reproduce the behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: >
+        We need to know a bit more about the context in which you run the rock.
+
+        - Are you running it as part of a charm or in a standalone fashion?
+
+        - Version of any applicable components, like Docker, Kubernetes, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: >
+        Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+        Fetch the logs using `juju debug-log --replay` and `kubectl logs ...`.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Issue
+<!-- What issue is this PR trying to solve? -->
+
+
+## Solution
+<!-- A summary of the solution addressing the above issue -->
+
+
+## Context
+<!-- What is some specialized knowledge relevant to this project/technology -->
+
+
+## Testing Instructions
+<!-- What steps need to be taken to test this PR? -->
+
+
+## Upgrade Notes
+<!-- To upgrade from an older revision of otelcol rock, ... -->

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,16 @@
+name: Pull Requests
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  pull-request:
+    name: PR
+    uses: canonical/observability/.github/workflows/rock-pull-request.yaml@v1
+    secrets: inherit

--- a/.github/workflows/rock-release-dev.yaml
+++ b/.github/workflows/rock-release-dev.yaml
@@ -1,0 +1,18 @@
+name: "Publish rock to GHCR:dev"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: canonical/observability/.github/workflows/rock-release-dev.yaml@v1
+    secrets: inherit
+    with:
+      rock-name: git-sync

--- a/.github/workflows/rock-release-oci-factory.yaml
+++ b/.github/workflows/rock-release-oci-factory.yaml
@@ -1,0 +1,14 @@
+name: Open a PR to OCI Factory
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: canonical/observability/.github/workflows/rock-release-oci-factory.yaml@v1
+    secrets: inherit
+    with:
+      rock-name: git-sync

--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -1,0 +1,21 @@
+name: Update rock
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  build:
+    uses: canonical/observability/.github/workflows/rock-update.yaml@v1
+    secrets: inherit
+    with:
+      rock-name: git-sync
+      source-repo: kubernetes/git-sync
+      check-go: true
+      update-script: |
+        # At this point, the reusable workflow already replaced the versions in the yaml
+        # and set the envvar VERSION for us to use here.
+        # All that's left is to update the `version.VERSION=...` string
+        sed -i "s|version.VERSION=[^']*|version.VERSION=$VERSION|g" "$rockcraft_yaml"
+        

--- a/4.5.1/.trivyignore
+++ b/4.5.1/.trivyignore
@@ -1,7 +1,0 @@
-# Upstream CVEs
-
-
-github.com/golang-jwt/jwt/v4 - jwt-go allows excessive memory allocation during header parsing
-# no code path in v4.4.0 calls this vulnerability
-CVE-2025-30204	
-

--- a/4.5.1/.trivyignore
+++ b/4.5.1/.trivyignore
@@ -1,0 +1,7 @@
+# Upstream CVEs
+
+
+github.com/golang-jwt/jwt/v4 - jwt-go allows excessive memory allocation during header parsing
+# no code path in v4.4.0 calls this vulnerability
+CVE-2025-30204	
+

--- a/4.5.1/rockcraft.yaml
+++ b/4.5.1/rockcraft.yaml
@@ -9,7 +9,7 @@ services:
     # enable the /metrics endpoint so we can liveness-check the rock.
     command: git-sync [ --repo https://github.com/kubernetes/git-sync/ --root git-sync --http-metrics --http-bind :1234 ]
     override: replace
-    startup: disabled
+    startup: enabled
 
 platforms:
   amd64:

--- a/4.5.1/rockcraft.yaml
+++ b/4.5.1/rockcraft.yaml
@@ -1,0 +1,51 @@
+name: git-sync
+summary: Petrified git-sync.
+description: "Git-sync sidecar process."
+version: "4.5.1"
+base: ubuntu@24.04
+license: Apache-2.0
+services:
+  git-sync:
+    # enable the /metrics endpoint so we can liveness-check the rock.
+    command: git-sync [ --repo https://github.com/kubernetes/git-sync/ --root git-sync --http-metrics --http-bind :1234 ]
+    override: replace
+    startup: disabled
+
+platforms:
+  amd64:
+  arm64:
+  ppc64el:
+  s390x:
+
+parts:
+  git:
+    plugin: nil
+    stage-packages:
+      - git
+
+  git-sync:
+    plugin: go
+    source: https://github.com/kubernetes/git-sync
+    source-type: git
+    source-tag: "v4.5.1"
+    source-depth: 1
+    build-snaps:
+      - go/1.25/stable
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOFLAGS: -trimpath -ldflags=-w -ldflags=-s '-ldflags=-X k8s.io/git-sync/pkg/version.VERSION=4.5.1'
+
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
+
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - git
+      - git-sync
+      - ca-certs
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query


### PR DESCRIPTION
Currently, if you `git-sync --version` from the rock it will say UNKNOWN, because the following flag was missing:
```
-ldflags=-X k8s.io/git-sync/pkg/version.VERSION=...
```

In this PR:
- Add the `.github` folder as everywhere else
- Build rock slightly differently than previously: rely more on the go plugin, and set GOFLAGS per upstream.
- Set the `update-script` to update the GOFLAGS with the version.
- Add rock for latest 4.x.