### PR TITLE
Add runtime-deps part for future proxy addition in cos-config charm

### DIFF
--- a/4.5.1/rockcraft.yaml
+++ b/4.5.1/rockcraft.yaml
@@ -18,10 +18,12 @@ platforms:
   s390x:
 
 parts:
-  git:
+  runtime-deps:
     plugin: nil
     stage-packages:
       - git
+      - openssh-client
+      - socat
 
   git-sync:
     plugin: go
@@ -42,7 +44,7 @@ parts:
   deb-security-manifest:
     plugin: nil
     after:
-      - git
+      - runtime-deps
       - git-sync
       - ca-certs
     override-prime: |


### PR DESCRIPTION
To accommodate a [future addition to cos-config](https://github.com/canonical/cos-configuration-k8s-operator/issues/119), we need to have socat and openssh-client added to the oci image ([ref](https://github.com/kubernetes/git-sync/issues/279)).
